### PR TITLE
feat: add pagination limit to room chats query

### DIFF
--- a/apps/http-backend/src/services/user.service.ts
+++ b/apps/http-backend/src/services/user.service.ts
@@ -94,10 +94,10 @@ export class UserService {
 
     return room;
   }
-
   static async getRoomChats(roomId: string) {
     const chats = await prisma.chat.findMany({
       where: { roomId },
+      take: 50,
       include: {
         user: {
           select: {


### PR DESCRIPTION
Added pagination limit to the getRoomChats query to improve performance:
- Limited chat messages to 50 most recent messages
- This prevents overloading the client with too many messages
- Improves initial load time for rooms with many messages

This is a first step towards proper pagination. Future improvements could include:
- Cursor-based pagination for older messages
- Configurable page size
- Real-time message updates